### PR TITLE
Build as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}/cmake.modules" CACHE STRING "module-path")
+set( CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}/cmake.modules" )
 project(sywu)
 
 #option(SYWU_TESTS "Build unit tests." OFF)
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-set(SYWU_SOURCES ${CMAKE_SOURCE_DIR})
-set(SYWU_BUILD_PATH ${CMAKE_BINARY_DIR})
+set(SYWU_SOURCES ${CMAKE_CURRENT_SOURCE_DIR})
+set(SYWU_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
 include(configure-platform)
 
 add_subdirectory(src)

--- a/cmake.modules/gtest.cmake
+++ b/cmake.modules/gtest.cmake
@@ -1,4 +1,11 @@
 cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
+
+find_package(GTest)
+if (${GTEST_FOUND})
+message( "Using GTest from System")
+SET ( SYWU_TEST_LIBS  GTest::GTest GTest::Main )
+else()
+
 #######################################
 # START OF GTEST DOWNLOAD
 #######################################
@@ -44,6 +51,7 @@ add_subdirectory("${GTEST_DOWNLOAD_DIR}/googletest-src"
 
 message(GTEST_SOURCE = ${gtest_SOURCE_DIR})
 message(GMOCK_SOURCE = ${gmock_SOURCE_DIR})
-include_directories("${gtest_SOURCE_DIR}/include"
-                 "${gmock_SOURCE_DIR}/include"
-)
+
+set(GTEST_INCLUDE_DIRS "${gtest_SOURCE_DIR}/include" "${gmock_SOURCE_DIR}/include")
+set(SYWU_TEST_LIBS gtest_main )
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${CMAKE_CURRENT_LIST_DIR}/../cmake.modules" CACHE STRING "module-path")
-
 include(configure-target)
 
 project(sywu_lib VERSION 1.0.0 LANGUAGES CXX)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ enable_testing()
 
 include(configure-target)
 include(gtest)
-include_directories(${CMAKE_SOURCE_DIR}/tests)
+include_directories( ${SYWU_SOURCES}/tests ${GTEST_INCLUDE_DIRS} )
 
 set (SOURCES
     test_main.cpp
@@ -15,7 +15,7 @@ set (SOURCES
 )
 
 add_executable(unittests ${SOURCES})
-target_link_libraries(unittests gtest_main sywu)
-#target_include_directories(unittests PRIVATE ${CMAKE_SOURCE_DIR}/tests)
+target_link_libraries(unittests ${SYWU_TEST_LIBS} sywu)
+#target_include_directories(unittests PRIVATE ${SYWU_SOURCES}/tests)
 configure_target(unittests)
-add_test(NAME test-1 COMMAND unittests "--gtest_output=xml:unittest.xml" WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+add_test(NAME test-1 COMMAND unittests "--gtest_output=xml:unittest.xml" WORKING_DIRECTORY "${SYWU_BUILD_PATH}")


### PR DESCRIPTION
This patch allows SYWU to be used as a subproject and allows the use of a system installed GTest library as well.
